### PR TITLE
Upgrade dependencies to latest patch versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@emailjs/browser": "^4.4.1",
-        "framer-motion": "^12.42.1",
+        "framer-motion": "^12.42.2",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-hot-toast": "^2.6.0",
@@ -2448,12 +2448,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.42.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.1.tgz",
-      "integrity": "sha512-Q2rHK14w8lavWk3MiF1wihcV1sCVsSYrRSaoqJ5eChG7CUNTKxDUgoMesiUSmMBjFpBRPWGrLvzymRrm0jnwFA==",
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.42.1",
+        "motion-dom": "^12.42.2",
         "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
@@ -3721,9 +3721,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.42.1",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.1.tgz",
-      "integrity": "sha512-dnBr0vtpJLvTVm+SIi8o7yh8jD57Bv7++nkkoeq85QW+QJqM+RIIoyvu5LyZ186dILUMHzkxv5sQveTxuOcOBw==",
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.39.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@emailjs/browser": "^4.4.1",
-        "framer-motion": "^12.38.0",
+        "framer-motion": "^12.42.1",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-hot-toast": "^2.6.0",
-        "react-icons": "^5.6.0",
+        "react-icons": "^5.7.0",
         "react-vertical-timeline-component": "^4.0.0"
       },
       "devDependencies": {
@@ -27,7 +27,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
         "sass-embedded": "^1.99.0",
-        "vite": "^8.1.0"
+        "vite": "^8.1.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2448,12 +2448,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.42.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.0.tgz",
-      "integrity": "sha512-wp7EJnfWaaEScVygKv3e20udoRz+LbtxScsuTkakAxfXmt+ReC6WyPW2nINRAGvd+hG9odwcjBLyOTPjH5pBRA==",
+      "version": "12.42.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.1.tgz",
+      "integrity": "sha512-Q2rHK14w8lavWk3MiF1wihcV1sCVsSYrRSaoqJ5eChG7CUNTKxDUgoMesiUSmMBjFpBRPWGrLvzymRrm0jnwFA==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.42.0",
+        "motion-dom": "^12.42.1",
         "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
@@ -3721,9 +3721,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.42.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.0.tgz",
-      "integrity": "sha512-M63h4n8R+quJdNhBwuLlgxM+OLYa9+I/T2pzDRboB9fLXRdbou+Gw7Zury+SkpaCyACP1JHSjHgZ1EgTkBr30w==",
+      "version": "12.42.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.1.tgz",
+      "integrity": "sha512-dnBr0vtpJLvTVm+SIi8o7yh8jD57Bv7++nkkoeq85QW+QJqM+RIIoyvu5LyZ186dILUMHzkxv5sQveTxuOcOBw==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.39.0"
@@ -4149,9 +4149,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
-      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.7.0.tgz",
+      "integrity": "sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
@@ -5301,16 +5301,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
-      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
+      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "~1.1.2",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
-    "framer-motion": "^12.38.0",
+    "framer-motion": "^12.42.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-hot-toast": "^2.6.0",
-    "react-icons": "^5.6.0",
+    "react-icons": "^5.7.0",
     "react-vertical-timeline-component": "^4.0.0"
   },
   "devDependencies": {
@@ -29,6 +29,6 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
     "sass-embedded": "^1.99.0",
-    "vite": "^8.1.0"
+    "vite": "^8.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
-    "framer-motion": "^12.42.1",
+    "framer-motion": "^12.42.2",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-hot-toast": "^2.6.0",


### PR DESCRIPTION
## Summary
Updated several dependencies to their latest patch and minor versions to improve stability and access new features.

## Changes
- **framer-motion**: `^12.38.0` → `^12.42.2` (minor version bump with bug fixes and improvements)
- **react-icons**: `^5.6.0` → `^5.7.0` (minor version bump with new icons and enhancements)
- **vite**: `^8.1.0` → `^8.1.2` (patch version bump with bug fixes)

## Notes
All updates are within the existing semver constraints and should be backward compatible. The lockfile has been updated with transitive dependency resolutions.

https://claude.ai/code/session_019oaBGEQLPbp3cxQcY3QgX9